### PR TITLE
TCIL-CWT-3142: update compileSdkVersion for Android

### DIFF
--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description         = package['description']
   s.homepage            = package['homepage']
   s.license             = package['license']
-  s.author              = package['author']
+  s.authors             = package['authors']
   s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
   s.platform              = :ios, '10.3'
   s.ios.deployment_target = '10.3'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Wifi configuration.
 This library was written to config iot devices. With iOS 11 Apple introduced NEHotspotConfiguration class for wifi configuration. Library supports same functionality on ios and android.
 
 ## 1.0.1
+iOS:
 * Add a podspec to support autolinking in React Native versions >= 0.60
+
+Android: 
+* Update compileSdkVersion to 28
 
 ## 1.0.0
 * Optional Force binding to a Wifi on both iOS and Android platforms

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "wifi",
     "iot"
   ],
-  "author": "tadasr",
+  "authors": [
+    "tadasr"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tadasr/react-native-iot-wifi/issues"


### PR DESCRIPTION
I also added back the "authors" tag in package.json to better match the package.json in the upstream repo.  I'd changed it in a previous commit.