### PR TITLE
Allow Android Q devices to connect to a wifi network and handle null ssids

### DIFF
--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -68,10 +68,6 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
     }
 
     private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork, Callback callback) {
-        if (Build.VERSION.SDK_INT > 28) {
-            callback.invoke("Not supported on Android Q");
-            return;
-        }
         if (!removeSSID(ssid)) {
             callback.invoke(errorFromCode(FailureCodes.SYSTEM_ADDED_CONFIG_EXISTS));
             return;

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -267,7 +267,9 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         String comparableSSID = ('"' + ssid + '"'); // Add quotes because wifiConfig.SSID has them
         if (configList != null) {
             for (WifiConfiguration wifiConfig : configList) {
-                if (wifiConfig.SSID.equals(comparableSSID)) {
+                String savedSSID = wifiConfig.SSID;
+                if (savedSSID == null) continue; // In few cases SSID is found to be null, ignore those configs
+                if (savedSSID.equals(comparableSSID)) {
                     Log.d("IoTWifi", "Found Matching Wifi: "+ wifiConfig.toString());
                     existingNetworkConfigForSSID = wifiConfig;
                     break;

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -24,6 +24,20 @@ class FailureCodes {
     static int FAILED_TO_BIND_CONFIG = 4;
 }
 
+class IOTWifiCallback {
+    private Callback callback;
+
+    public IOTWifiCallback(Callback callback) {
+        this.callback = callback;
+    }
+
+    public void invoke(Object... args) {
+        if (callback == null) return;
+        callback.invoke(args);
+        callback = null;
+    }
+}
+
 public class IOTWifiModule extends ReactContextBaseJavaModule {
     private WifiManager wifiManager;
     private ConnectivityManager connectivityManager;
@@ -67,9 +81,10 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         }).start();
     }
 
-    private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork, Callback callback) {
+    private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork, final Callback callback) {
+        IOTWifiCallback iotWifiCallback = new IOTWifiCallback(callback);
         if (!removeSSID(ssid)) {
-            callback.invoke(errorFromCode(FailureCodes.SYSTEM_ADDED_CONFIG_EXISTS));
+            iotWifiCallback.invoke(errorFromCode(FailureCodes.SYSTEM_ADDED_CONFIG_EXISTS));
             return;
         }
 
@@ -81,31 +96,31 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
             wifiManager.disconnect();
             boolean success =  wifiManager.enableNetwork(networkId, true);
             if (!success) {
-                callback.invoke(errorFromCode(FailureCodes.FAILED_TO_ADD_CONFIG));
+                iotWifiCallback.invoke(errorFromCode(FailureCodes.FAILED_TO_ADD_CONFIG));
                 return;
             }
             success = wifiManager.reconnect();
             if (!success) {
-                callback.invoke(errorFromCode(FailureCodes.FAILED_TO_CONNECT));
+                iotWifiCallback.invoke(errorFromCode(FailureCodes.FAILED_TO_CONNECT));
                 return;
             }
             boolean connected = pollForValidSSSID(10, ssid);
             if (!connected) {
-                callback.invoke(errorFromCode(FailureCodes.FAILED_TO_CONNECT));
+                iotWifiCallback.invoke(errorFromCode(FailureCodes.FAILED_TO_CONNECT));
                 return;
             }
             if (!bindNetwork) {
-                callback.invoke();
+                iotWifiCallback.invoke();
                 return;
             }
             try {
-                bindToNetwork(ssid, callback);
+                bindToNetwork(ssid, iotWifiCallback);
             } catch (Exception e) {
                 Log.d("IoTWifi", "Failed to bind to Wifi: " + ssid);
-                callback.invoke();
+                iotWifiCallback.invoke();
             }
         } else {
-            callback.invoke(errorFromCode(FailureCodes.FAILED_TO_ADD_CONFIG));
+            iotWifiCallback.invoke(errorFromCode(FailureCodes.FAILED_TO_ADD_CONFIG));
         }
     }
 
@@ -145,7 +160,7 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         return false;
     }
 
-    private void bindToNetwork(final String ssid, final Callback callback) {
+    private void bindToNetwork(final String ssid, final IOTWifiCallback callback) {
         NetworkRequest.Builder builder = new NetworkRequest.Builder();
         builder.addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
         connectivityManager.requestNetwork(builder.build(), new ConnectivityManager.NetworkCallback() {

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -214,7 +214,10 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
         if (existingNetworkId == -1) {
             return success;
         }
-        success = wifiManager.removeNetwork(existingNetworkId) && wifiManager.saveConfiguration();
+        success = wifiManager.removeNetwork(existingNetworkId);
+        if (success && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            success = wifiManager.saveConfiguration();
+        }
         //If not our config then success would be false
         return success;
     }


### PR DESCRIPTION
After a bit more testing turns out Android Q is still supporting the old API and rejecting the wifi connect calls for it makes less sense.
This PR will 

1. Android Fix: Allows the connect API to be used by Android Q again.
2. Android Fix: The reconnect to a previously self added wifi configuration for `< Oreo`
3. Android Fix: An `illegal violation` crash related to callback being invoked more than once when attempting to force bind to a wifi network