### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iot-wifi",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Connect to WiFi with React Native on Android and iOS.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bump package version from 1.1.0 to 1.2.0 after pulling in changes to support Android Q and handle null SSIDs